### PR TITLE
Issue 23: pack command cannot detect the appropriate builder

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,4 +13,6 @@ if [ -z "${pack_exe}" ]; then
   fi
 fi
 
+# mounted as bound volume to the root of the executing repository
+cd /github/workspace
 eval "${pack_exe} ${INPUT_ARGS}"


### PR DESCRIPTION
`pack` should execute relative to the root of the code repo

Closes #23 