### PR TITLE
Wait 30s before testing images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,11 +85,11 @@ jobs:
         with:
           args: 'build ${{ env.IMG_NAME }} --builder ${{ env.BUILDER }} --path ${{ env.TEST_APP_PATH }} --publish'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PACKAGES_PAT }}
           registry: ${{ env.REGISTRY }}
       - name: Test App
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
+          echo ${{ secrets.GH_PACKAGES_PAT }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
           sleep 30s
           curl --request GET --url http://localhost:8080
@@ -98,14 +98,14 @@ jobs:
         with:
           args: 'rebase ${{ env.IMG_NAME }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PACKAGES_PAT }}
           registry: ${{ env.REGISTRY }}
       - name: Inspect Image
         uses: ./
         with:
           args: 'inspect-image ${{ env.IMG_NAME }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PACKAGES_PAT }}
           registry: ${{ env.REGISTRY }}
       - name: Clean Up
         run: |
@@ -121,7 +121,7 @@ jobs:
         with:
           args: 'build ${{ env.IMG_NAME }} --builder ${{ env.BUILDER }} --path ${{ env.TEST_APP_PATH }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PACKAGES_PAT }}
           registry: ${{ env.REGISTRY }}
       - name: Test App
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,11 +82,11 @@ jobs:
         with:
           args: 'build ${{ env.IMG_NAME }} --builder ${{ env.BUILDER }} --path ${{ env.TEST_APP_PATH }} --publish'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GH_PACKAGES_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - name: Test App
         run: |
-          echo ${{ secrets.GH_PACKAGES_PAT }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
           curl localhost:8080
       - name: Pack Rebase
@@ -94,14 +94,14 @@ jobs:
         with:
           args: 'rebase ${{ env.IMG_NAME }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GH_PACKAGES_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - name: Inspect Image
         uses: ./
         with:
           args: 'inspect-image ${{ env.IMG_NAME }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GH_PACKAGES_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - name: Clean Up
         run: |
@@ -117,7 +117,7 @@ jobs:
         with:
           args: 'build ${{ env.IMG_NAME }} --builder ${{ env.BUILDER }} --path ${{ env.TEST_APP_PATH }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GH_PACKAGES_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - name: Test App
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp test_img
-          curl localhost:8080
+          curl http://localhost:8080
       - name: Pack Rebase
         uses: ./
         with:
@@ -59,7 +59,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl localhost:8080
+          curl http://localhost:8080
       - name: Pack Rebase
         uses: ./
         with:
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl localhost:8080
+          curl http://localhost:8080
       - name: Pack Rebase
         uses: ./
         with:
@@ -122,7 +122,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl localhost:8080
+          curl http://localhost:8080
       - name: Pack Rebase
         uses: ./
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp test_img
-          curl http://localhost:8080
+          curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: ./
         with:
@@ -59,7 +59,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl http://localhost:8080
+          curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: ./
         with:
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl http://localhost:8080
+          curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: ./
         with:
@@ -122,7 +122,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl http://localhost:8080
+          curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: ./
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp test_img
+          curl --version
+          sleep 30s
           curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: ./
@@ -59,6 +61,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
+          sleep 30s
           curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: ./
@@ -88,6 +91,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
+          sleep 30s
           curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: ./
@@ -122,6 +126,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
+          sleep 30s
           curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: ./

--- a/.github/workflows/v1.yml
+++ b/.github/workflows/v1.yml
@@ -90,11 +90,11 @@ jobs:
         with:
           args: 'build ${{ env.IMG_NAME }} --builder ${{ env.BUILDER }} --path ${{ env.TEST_APP_PATH }} --publish'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PACKAGES_PAT }}
           registry: ${{ env.REGISTRY }}
       - name: Test App
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
+          echo ${{ secrets.GH_PACKAGES_PAT }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
           sleep 30s
           curl --request GET --url http://localhost:8080
@@ -103,14 +103,14 @@ jobs:
         with:
           args: 'rebase ${{ env.IMG_NAME }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PACKAGES_PAT }}
           registry: ${{ env.REGISTRY }}
       - name: Inspect Image
         uses: dfreilich/pack-action@v1
         with:
           args: 'inspect-image ${{ env.IMG_NAME }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PACKAGES_PAT }}
           registry: ${{ env.REGISTRY }}
       - name: Clean Up
         run: |
@@ -127,7 +127,7 @@ jobs:
         with:
           args: 'build ${{ env.IMG_NAME }} --builder ${{ env.BUILDER }} --path ${{ env.TEST_APP_PATH }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PACKAGES_PAT }}
           registry: ${{ env.REGISTRY }}
       - name: Test App
         run: |

--- a/.github/workflows/v1.yml
+++ b/.github/workflows/v1.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp test_img
-          curl localhost:8080
+          curl http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
         with:
@@ -63,7 +63,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl localhost:8080
+          curl http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
         with:
@@ -93,7 +93,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl localhost:8080
+          curl http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
         with:
@@ -128,7 +128,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl localhost:8080
+          curl http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
         with:

--- a/.github/workflows/v1.yml
+++ b/.github/workflows/v1.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp test_img
+          curl --version
+          sleep 30s
           curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
@@ -63,6 +65,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
+          sleep 30s
           curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
@@ -93,6 +96,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
+          sleep 30s
           curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
@@ -128,6 +132,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
+          sleep 30s
           curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1

--- a/.github/workflows/v1.yml
+++ b/.github/workflows/v1.yml
@@ -87,11 +87,11 @@ jobs:
         with:
           args: 'build ${{ env.IMG_NAME }} --builder ${{ env.BUILDER }} --path ${{ env.TEST_APP_PATH }} --publish'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GH_PACKAGES_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - name: Test App
         run: |
-          echo ${{ secrets.GH_PACKAGES_PAT }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
           curl localhost:8080
       - name: Pack Rebase
@@ -99,14 +99,14 @@ jobs:
         with:
           args: 'rebase ${{ env.IMG_NAME }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GH_PACKAGES_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - name: Inspect Image
         uses: dfreilich/pack-action@v1
         with:
           args: 'inspect-image ${{ env.IMG_NAME }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GH_PACKAGES_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - name: Clean Up
         run: |
@@ -123,7 +123,7 @@ jobs:
         with:
           args: 'build ${{ env.IMG_NAME }} --builder ${{ env.BUILDER }} --path ${{ env.TEST_APP_PATH }}'
           username: ${{ env.USERNAME }}
-          password: ${{ secrets.GH_PACKAGES_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - name: Test App
         run: |

--- a/.github/workflows/v1.yml
+++ b/.github/workflows/v1.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp test_img
-          curl http://localhost:8080
+          curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
         with:
@@ -63,7 +63,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl http://localhost:8080
+          curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
         with:
@@ -93,7 +93,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ env.USERNAME }} --password-stdin ${{ env.REGISTRY }}
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl http://localhost:8080
+          curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
         with:
@@ -128,7 +128,7 @@ jobs:
       - name: Test App
         run: |
           docker run -d -p 8080:8080 --name testapp ${{ env.IMG_NAME }}
-          curl http://localhost:8080
+          curl --request GET --url http://localhost:8080
       - name: Pack Rebase
         uses: dfreilich/pack-action@v1
         with:


### PR DESCRIPTION
~GH documentation recommends using GITHB_TOKEN in place of a PAT for ghcr.io authentication, so this updates the workflows to do that.
https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions\#upgrading-a-workflow-that-accesses-ghcrio~

This (a) didn't seem to work (despite having given my packages appropriate permissions), and (b) isn't critical for security purposes, given that it is only test packages that I am exposing, and no secure packages depended upon by any other system. 

As such, this PR is repurposed to waiting a bit to make sure the server is running before hitting it. 
Signed-off-by: David Freilich <david.freilich@appsflyer.com>

